### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,50 +23,50 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-WRF							KEYWORD1
-WRFConfig					KEYWORD1
+WRF	KEYWORD1
+WRFConfig	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-setupParam					KEYWORD2
-loopHandler					KEYWORD2
-init						KEYWORD2
-connect						KEYWORD2
-prepareLinkUpMode			KEYWORD2
-poll						KEYWORD2
-setPollInterval				KEYWORD2
-upgrade						KEYWORD2
-checkPendingUpgrade			KEYWORD2
-startWrfUpgrade				KEYWORD2
-startClientUpgrade			KEYWORD2
-send						KEYWORD2
-canSendCommand				KEYWORD2
-isOnline					KEYWORD2
-sendMessage					KEYWORD2
+setupParam	KEYWORD2
+loopHandler	KEYWORD2
+init	KEYWORD2
+connect	KEYWORD2
+prepareLinkUpMode	KEYWORD2
+poll	KEYWORD2
+setPollInterval	KEYWORD2
+upgrade	KEYWORD2
+checkPendingUpgrade	KEYWORD2
+startWrfUpgrade	KEYWORD2
+startClientUpgrade	KEYWORD2
+send	KEYWORD2
+canSendCommand	KEYWORD2
+isOnline	KEYWORD2
+sendMessage	KEYWORD2
 sendCommandWithoutParams	KEYWORD2
-sendCommand					KEYWORD2
-sendIntrospect				KEYWORD2
-setVisibility				KEYWORD2
-getStatus					KEYWORD2
-onError						KEYWORD2
-onConnected					KEYWORD2
-onMessageSent				KEYWORD2
-onMessageReceived			KEYWORD2
-onPendingUpgrades			KEYWORD2
-onNotConnected				KEYWORD2
-onStatusReceived			KEYWORD2
-clearMessageQueue			KEYWORD2
-getListSize					KEYWORD2
-addToList					KEYWORD2
-addToDictionary				KEYWORD2
+sendCommand	KEYWORD2
+sendIntrospect	KEYWORD2
+setVisibility	KEYWORD2
+getStatus	KEYWORD2
+onError	KEYWORD2
+onConnected	KEYWORD2
+onMessageSent	KEYWORD2
+onMessageReceived	KEYWORD2
+onPendingUpgrades	KEYWORD2
+onNotConnected	KEYWORD2
+onStatusReceived	KEYWORD2
+clearMessageQueue	KEYWORD2
+getListSize	KEYWORD2
+addToList	KEYWORD2
+addToDictionary	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-DEBUG_ALL					LITERAL1
-DEBUG_NONE					LITERAL1
-ERROR_ALL					LITERAL1
-ERROR_LOCAL					LITERAL1
-ERROR_REMOTE				LITERAL1
-ERROR_NONE					LITERAL1
+DEBUG_ALL	LITERAL1
+DEBUG_NONE	LITERAL1
+ERROR_ALL	LITERAL1
+ERROR_LOCAL	LITERAL1
+ERROR_REMOTE	LITERAL1
+ERROR_NONE	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords